### PR TITLE
Update client with new API request headers

### DIFF
--- a/lib/spreadshirt_client.rb
+++ b/lib/spreadshirt_client.rb
@@ -59,7 +59,7 @@ module SpreadshirtClient
       # Will this work properly for passing in the user agent? Looks like yes based on:
       # https://github.com/rest-client/rest-client/blob/f450a0f086f1cd1049abbef2a2c66166a1a9ba71/spec/unit/request_spec.rb#L623
       # TODO: move this back to the AthleteOriginals app when things are working again
-      opts[:user_agent] ||= "Athlete-Originals/2.0 (http://www.athleteoriginals.com; support@athleteoriginals.com)"
+      opts[:user_agent] ||= "Athlete-Originals/2.0 (https://www.athleteoriginals.com; support@athleteoriginals.com)"
 
       opts[:content_type] ||= "application/xml"
 

--- a/lib/spreadshirt_client.rb
+++ b/lib/spreadshirt_client.rb
@@ -49,7 +49,9 @@ module SpreadshirtClient
     def headers_for(method_symbol, path, options)
       headers = {}
 
-      headers[:authorization] = authorize(method_for(method_symbol), path, options[:session]) if options[:authorization]
+      # The following line was changed to remove a trailing: if options[:authorization]
+      # In other words, authorization headers are now always added to the request
+      headers[:authorization] = authorize(method_for(method_symbol), path, options[:session])
 
       opts = options.dup
       opts.delete :session

--- a/lib/spreadshirt_client.rb
+++ b/lib/spreadshirt_client.rb
@@ -56,6 +56,11 @@ module SpreadshirtClient
       opts = options.dup
       opts.delete :session
 
+      # Will this work properly for passing in the user agent? Looks like yes based on:
+      # https://github.com/rest-client/rest-client/blob/f450a0f086f1cd1049abbef2a2c66166a1a9ba71/spec/unit/request_spec.rb#L623
+      # TODO: move this back to the AthleteOriginals app when things are working again
+      opts[:user_agent] ||= "Athlete-Originals/2.0 (http://www.athleteoriginals.com; support@athleteoriginals.com)"
+
       opts[:content_type] ||= "application/xml"
 
       opts.merge headers
@@ -82,4 +87,3 @@ module SpreadshirtClient
     end
   end
 end
-

--- a/lib/spreadshirt_client/version.rb
+++ b/lib/spreadshirt_client/version.rb
@@ -1,3 +1,3 @@
 module SpreadshirtClient
-  VERSION = "0.0.8"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
This PR changes the headers that are passed along with each Spreadshirt API request so that they reflect the updated API requirements:

1. Always pass the authorization headers
2. Add a User Agent as an additional header